### PR TITLE
add user creation + unregistered & registered user maps

### DIFF
--- a/includes/Context.hpp
+++ b/includes/Context.hpp
@@ -2,24 +2,39 @@
 #define CONTEXT_H
 
 #include "ft_irc.hpp"
+#include "Message.hpp"
+#include "User.hpp"
 
 class User;
-class Channel;
+/* class Channel; */
 
 class Context
 {
 	private:
+		std::map<int, User *> unregistered_users;
+		std::map<std::string, User *> registered_users;
+		/* std::map<std::string, Channel> channels; */
 
-		std::map<std::string, User> users;
-		std::map<std::string, Channel> channels;
+		Context( const Context & src );
+		Context & operator=( const Context & rhs );
 
 	public:
 		Context();
-		Context( const Context & src );
-		Context & operator=( const Context & rhs );
-		virtual ~Context();
+		~Context();
 
-		void transmit_message( void );
+		void create_unregistered_user( int socket );
+		void move_user_to_registered( User & user );
+		/* void add_new_channel( Channel & channel); */
+		/* void execute_message( User & sender, Message message ); */
+		/* void transmit_message( void ); */
+
+		User & get_user_by_socket( int socket );
+		User & get_user_by_nick( std::string nickname );
+
+		void debug_print_unregistered_users( void ) const;
+		void debug_print_registered_users( void ) const;
 };
+
+std::ostream & operator<<( std::ostream & os, Context const & obj );
 
 #endif /* CONTEXT_H */

--- a/includes/User.hpp
+++ b/includes/User.hpp
@@ -1,8 +1,9 @@
 #ifndef USER_H
 #define USER_H
 
-#include "Context.hpp"
 #include "ft_irc.hpp"
+
+class Context;
 
 class User
 {
@@ -25,6 +26,7 @@ class User
 		std::string const & get_username( void ) const;
 		std::string const & get_hostname( void ) const;
 		std::string const & get_identifier( void ) const;
+		int const & get_socket( void ) const;
 
 		void set_nickname( std::string nickname );
 		void set_username( std::string username );

--- a/includes/ft_irc.hpp
+++ b/includes/ft_irc.hpp
@@ -16,8 +16,9 @@
 #include <fcntl.h>
 #include <stdexcept>
 #include <map>
+#include <utility>
 #include <cstring>
-
+#include <stdexcept>
 
 # define SERVER_PREFIX ":ircserv.42.fr"
 # define SERVER_NAME "ircserv"

--- a/includes/ft_irc.hpp
+++ b/includes/ft_irc.hpp
@@ -18,6 +18,8 @@
 #include <map>
 #include <utility>
 #include <cstring>
+#include <exception>
+#include <new>
 #include <stdexcept>
 
 # define SERVER_PREFIX ":ircserv.42.fr"

--- a/sources/Context.cpp
+++ b/sources/Context.cpp
@@ -55,7 +55,7 @@ void Context::create_unregistered_user( int socket )
 	User * new_user = new User( *this, socket );
 	if ( new_user == NULL )
 	{
-		/* TODO: Throw fatal malloc error */
+		throw std::runtime_error( "User creation: Could not allocate memory." );
 	}
 	unregistered_users.insert( std::pair<int, User *>( socket, new_user ) );
 }

--- a/sources/Context.cpp
+++ b/sources/Context.cpp
@@ -1,0 +1,95 @@
+#include "Context.hpp"
+#include "User.hpp"
+#include <exception>
+#include <stdexcept>
+
+template <typename T, typename U>
+void delete_map( std::map<T, U> & map )
+{
+	typename std::map<T, U>::iterator it = map.begin();
+	for ( ; it != map.end(); it++ )
+	{
+		delete ( it->second );
+	}
+	map.clear();
+}
+
+Context::Context() {}
+Context::~Context()
+{
+	delete_map( unregistered_users );
+	delete_map( registered_users );
+	/* delete_map( channels ); */
+}
+
+User & Context::get_user_by_socket( int socket )
+{
+	std::map<int, User *>::iterator u_it = unregistered_users.find( socket );
+	if ( u_it != unregistered_users.end() )
+	{
+		return ( *unregistered_users[socket] );
+	}
+	std::map<std::string, User *>::iterator r_it = registered_users.begin();
+	for ( ; r_it != registered_users.end(); r_it++ )
+	{
+		if ( r_it->second->get_socket() == socket )
+		{
+			return ( *r_it->second );
+		}
+	}
+	throw std::out_of_range( "Could not find user by socket" );
+}
+
+User & Context::get_user_by_nick( std::string nickname )
+{
+	std::map<std::string, User *>::iterator it = registered_users.find( nickname );
+	if ( it != registered_users.end() )
+	{
+		return ( *registered_users[nickname] );
+	}
+	throw std::out_of_range( "Could not find user by nickname" );
+}
+
+void Context::create_unregistered_user( int socket )
+{
+	User * new_user = new User( *this, socket );
+	if ( new_user == NULL )
+	{
+		/* TODO: Throw fatal malloc error */
+	}
+	unregistered_users.insert( std::pair<int, User *>( socket, new_user ) );
+}
+
+void Context::move_user_to_registered( User & user )
+{
+	registered_users.insert( std::pair<std::string, User *>
+	                         ( user.get_nickname(),
+	                           &user ) );
+	unregistered_users.erase( user.get_socket() );
+}
+/* void Context::execute_message( User & sender, Message message ) {} */
+/* void Context::transmit_message( void ) {} */
+
+void Context::debug_print_unregistered_users( void ) const
+{
+	std::map<int, User *>::const_iterator it = unregistered_users.begin();
+	std::map<int, User *>::const_iterator it_end = unregistered_users.end();
+	std::cout << "Unregistered users :" << std::endl;
+	for ( ; it != it_end; it++ )
+	{
+		std::cout << "\t[" << it->second->get_socket() << "] "
+		          << it->second->get_identifier() << std::endl;
+	}
+}
+
+void Context::debug_print_registered_users( void ) const
+{
+	std::map<std::string, User *>::const_iterator it = registered_users.begin();
+	std::map<std::string, User *>::const_iterator it_end = registered_users.end();
+	std::cout << "Registered users :" << std::endl;
+	for ( ; it != it_end; it++ )
+	{
+		std::cout << "\t[" << it->second->get_socket() << "] "
+		          << it->second->get_identifier() << std::endl;
+	}
+}

--- a/sources/User.cpp
+++ b/sources/User.cpp
@@ -30,6 +30,11 @@ std::string const & User::get_identifier( void ) const
 	return ( this->identifier );
 }
 
+int const & User::get_socket( void ) const
+{
+	return ( this->socket );
+}
+
 void User::set_nickname( std::string nickname )
 {
 	this->nickname = nickname;


### PR DESCRIPTION
Ability to create a new user with the `create_unregistered_user` function.
Unregistered users are kept track of in a map and identified by socket rather than nickname for easy search.