### PR TITLE
fix privmsg reply to sender in channel

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -82,6 +82,7 @@ class Channel
 		void remove_user( User & user );
 		void update_user_nick( User & user, std::string new_nick );
 		void send_reply( std::string reply );
+		void send_reply( std::string reply, User & user_to_ignore );
 
 		std::list<User *> get_user_list( void );
 		unsigned int get_nbr_users( void );

--- a/sources/Channel.cpp
+++ b/sources/Channel.cpp
@@ -229,13 +229,24 @@ bool Channel::is_creator( std::string nickname )
 	return ( false );
 }
 
-
 void Channel::send_reply( std::string reply )
 {
 	std::map<std::string, User *>::iterator it = users.begin();
 	for ( ; it != users.end(); it++ )
 	{
 		it->second->send_reply( reply );
+	}
+}
+
+void Channel::send_reply( std::string reply, User & user_to_ignore )
+{
+	std::map<std::string, User *>::iterator it = users.begin();
+	for ( ; it != users.end(); it++ )
+	{
+		if (it->first != user_to_ignore.get_nickname() )
+		{
+			it->second->send_reply( reply );
+		}
 	}
 }
 

--- a/sources/Message_Handler.cpp
+++ b/sources/Message_Handler.cpp
@@ -567,7 +567,7 @@ void Message_Handler::handle_privmsg( Message & message )
 		Channel & dest_chan = context.get_channel_by_name( dest_nick );
 		if ( dest_chan.is_user_in_channel( sender ) )
 		{
-			dest_chan.send_reply( rpl::forward( sender, message ) );
+			dest_chan.send_reply( rpl::forward( sender, message ), sender );
 		}
 		else
 		{


### PR DESCRIPTION
Fix for the bug where a client in a channel sends a PRIVMSG and the reply is sent to everyone in the channel, including the PRIVMSG sender. This prevents the reply being sent to the sender.