### PR TITLE
Force disconnect user on bad password

### DIFF
--- a/includes/Application.hpp
+++ b/includes/Application.hpp
@@ -38,7 +38,6 @@ class Application
 		void initialize_server( void );
 		void wait_for_socket_event( void );
 		void connect_new_client( void );
-		void disconnect_client( int fd );
 		void read_client_sockets( void );
 		void read_message( int fd );
 		void get_commands_from_socket( int fd, std::string & message_buffer );
@@ -60,6 +59,7 @@ class Application
 		void client_timeout_check( void ); // Separate class
 		void launch_server( void );
 		void send_message(int socket, const std::string& message);
+		void disconnect_client( int fd );
 
 };
 

--- a/includes/Context.hpp
+++ b/includes/Context.hpp
@@ -74,6 +74,12 @@ class Context
 		void debug_print_unregistered_users( void ) const;
 		void debug_print_registered_users( void ) const;
 		void debug_print_channels( void ) const;
+
+		class CouldNotFindUserException : public std::exception
+		{
+			public:
+				virtual const char* what() const throw();
+		};
 };
 
 #endif /* CONTEXT_H */

--- a/includes/Context.hpp
+++ b/includes/Context.hpp
@@ -69,6 +69,7 @@ class Context
 
 		void check_connection_password( std::string password );
 		void send_message( int socket, std::string message );
+		void force_disconnect_user( User & user );
 
 		void debug_print_unregistered_users( void ) const;
 		void debug_print_registered_users( void ) const;

--- a/includes/log_event.hpp
+++ b/includes/log_event.hpp
@@ -6,7 +6,7 @@
 #define LOG_WARNING 2
 #define LOG_INFO 3
 
-#define LOG_LEVEL 1
+#define LOG_LEVEL 3
 
 
 #include <cstddef>

--- a/sources/Application.cpp
+++ b/sources/Application.cpp
@@ -22,9 +22,9 @@ Application::~Application()
 {
 	log_event::info( "Application: Terminating application" );
 	close( server.fd );
+	delete poll_fds;
 	delete passwords;
 	delete context;
-	delete poll_fds;
 }
 
 void Application::initialize_server( void )
@@ -175,8 +175,7 @@ void Application::disconnect_client( int fd )
 	{
 		if ( client_fds[i].fd == fd )
 		{
-      		/* close( fd );  // Close the client socket */
-			context->remove_user( fd );
+			context->remove_user( fd ); // Closes the client socket
       		client_fds.erase( client_fds.begin() + i );  // Remove the client from the vector
       		num_connections--;
       		break;

--- a/sources/Application.cpp
+++ b/sources/Application.cpp
@@ -1,4 +1,5 @@
 #include "Application.hpp"
+#include "Context.hpp"
 #include "ft_irc.hpp"
 #include "Password.hpp"
 #include "log_event.hpp"
@@ -176,7 +177,6 @@ void Application::disconnect_client( int fd )
 		if ( client_fds[i].fd == fd )
 		{
 			context->remove_user( fd ); // Closes the client socket
-			client_fds[i].fd = -1;
       		client_fds.erase( client_fds.begin() + i );  // Remove the client from the vector
       		num_connections--;
       		break;
@@ -212,6 +212,10 @@ void Application::get_commands_from_socket( int fd, std::string & message_buffer
 		{
 			log_event::info( "Application: Nothing more to read from socket", fd );
 			break ;
+		}
+		catch ( Context::CouldNotFindUserException & e )
+		{
+			log_event::warn( "Application: Context:", e.what() );
 		}
 	}
 }	

--- a/sources/Application.cpp
+++ b/sources/Application.cpp
@@ -159,7 +159,6 @@ void Application::connect_new_client( void )
 void Application::disconnect_client( int fd )
 {
 	log_event::info( "Application: Client disconnected from socket", fd );
-	context->remove_user( fd );
 
 	// Remove queued messages for the disconnected client
     std::vector<Message1>::iterator it = message_list.begin();
@@ -176,7 +175,8 @@ void Application::disconnect_client( int fd )
 	{
 		if ( client_fds[i].fd == fd )
 		{
-      		close( fd );  // Close the client socket
+      		/* close( fd );  // Close the client socket */
+			context->remove_user( fd );
       		client_fds.erase( client_fds.begin() + i );  // Remove the client from the vector
       		num_connections--;
       		break;

--- a/sources/Application.cpp
+++ b/sources/Application.cpp
@@ -176,6 +176,7 @@ void Application::disconnect_client( int fd )
 		if ( client_fds[i].fd == fd )
 		{
 			context->remove_user( fd ); // Closes the client socket
+			client_fds[i].fd = -1;
       		client_fds.erase( client_fds.begin() + i );  // Remove the client from the vector
       		num_connections--;
       		break;

--- a/sources/Context.cpp
+++ b/sources/Context.cpp
@@ -1,6 +1,7 @@
 #include "Context.hpp"
 #include "Channel.hpp"
 #include <iterator>
+#include <sstream>
 #include <stdexcept>
 #include "Password.hpp"
 #include "ft_irc.hpp"
@@ -191,7 +192,9 @@ User & Context::get_user_by_socket( int socket )
 			return ( *r_it->second );
 		}
 	}
-	throw std::out_of_range( "Context: Could not find user by socket" );
+	std::stringstream ss;
+	ss << socket;
+	throw std::out_of_range( "Context: Could not find user by socket " + ss.str() );
 }
 
 User & Context::get_user_by_nick( std::string nickname )

--- a/sources/Context.cpp
+++ b/sources/Context.cpp
@@ -362,3 +362,7 @@ void Context::send_message( int socket, std::string message )
 	application.send_message( socket, message );
 }
 
+void Context::force_disconnect_user( User & user )
+{
+	application.disconnect_client( user.get_socket() );
+}

--- a/sources/Context.cpp
+++ b/sources/Context.cpp
@@ -194,7 +194,8 @@ User & Context::get_user_by_socket( int socket )
 	}
 	std::stringstream ss;
 	ss << socket;
-	throw std::out_of_range( "Context: Could not find user by socket " + ss.str() );
+	throw CouldNotFindUserException();
+	/* throw std::out_of_range( "Context: Could not find user by socket " + ss.str() ); */
 }
 
 User & Context::get_user_by_nick( std::string nickname )
@@ -368,4 +369,9 @@ void Context::send_message( int socket, std::string message )
 void Context::force_disconnect_user( User & user )
 {
 	application.disconnect_client( user.get_socket() );
+}
+
+const char* Context::CouldNotFindUserException::what() const throw()
+{
+	return ( "Could not find user by name or socket" );
 }

--- a/sources/Message_Handler.cpp
+++ b/sources/Message_Handler.cpp
@@ -561,6 +561,7 @@ void Message_Handler::handle_pass( Message & message )
 	{
 		log_event::warn( "Message_Handler: PASS: ", e.what() );
 		sender.send_reply( rpl::err_passwdmismatch( sender ) );
+		context.force_disconnect_user( sender );
 	}
 	catch ( std::exception & e )
 	{

--- a/sources/User.cpp
+++ b/sources/User.cpp
@@ -18,7 +18,6 @@ User::~User()
 {
 	log_event::info( "User: closing socket for user \"" + this->nickname + "\": socket", this->socket );
 	close( this->socket );
-	this->socket = -1;
 }
 
 std::string const & User::get_nickname( void ) const

--- a/sources/User.cpp
+++ b/sources/User.cpp
@@ -18,6 +18,7 @@ User::~User()
 {
 	log_event::info( "User: closing socket for user \"" + this->nickname + "\": socket", this->socket );
 	close( this->socket );
+	this->socket = -1;
 }
 
 std::string const & User::get_nickname( void ) const


### PR DESCRIPTION
Fixes 2 things:
1. A client who wants to connect but provides the wrong connection password is kicked from the server immediately to make room for other clients.
2. An error with context not finding a user when processing a command from a user who was disconnected in the meantime.